### PR TITLE
[DUMMY] DICOM type hinting example

### DIFF
--- a/rai/__main__.py
+++ b/rai/__main__.py
@@ -22,6 +22,7 @@ import click
 
 from ._cli import docs as _docs
 from ._cli import propagate as _propagate
+from .dicom import dummy as _dummy
 
 
 @click.group()
@@ -45,6 +46,11 @@ def propagate():
     """
 
     _propagate.run()
+
+
+@cli.command()
+def dummy():
+    _dummy.run()
 
 
 if __name__ == "__main__":

--- a/rai/dicom/dummy.py
+++ b/rai/dicom/dummy.py
@@ -50,13 +50,9 @@ def _type_hint_effects():
 
     # Without implementing the type checking, any valid CS value can be
     # assigned to this variable without warning
-    b.ROIContourSequence[0].ContourSequence[
-        0
-    ].ContourGeometricType = "ANYTHING_GOES_BECAUSE_THE_TYPE_ON_PYDICOM_IS_ANY"
+    b.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "ANYTHING_GOES"
     assert a != b
 
-    a.ROIContourSequence[0].ContourSequence[
-        0
-    ].ContourGeometricType = "PYRIGHT_WONT_LIKE_THIS"
+    a.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "PYRIGHT_UNHAPPY"
 
     print("Everything ran, no errors!")

--- a/rai/dicom/dummy.py
+++ b/rai/dicom/dummy.py
@@ -52,3 +52,5 @@ def _type_hint_effects():
     # assigned to this variable without warning
     b.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "ANYTHING_GOES"
     assert a != b
+
+    print("Everything ran, no errors!")

--- a/rai/dicom/dummy.py
+++ b/rai/dicom/dummy.py
@@ -50,7 +50,13 @@ def _type_hint_effects():
 
     # Without implementing the type checking, any valid CS value can be
     # assigned to this variable without warning
-    b.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "ANYTHING_GOES"
+    b.ROIContourSequence[0].ContourSequence[
+        0
+    ].ContourGeometricType = "ANYTHING_GOES_BECAUSE_THE_TYPE_ON_PYDICOM_IS_ANY"
     assert a != b
+
+    a.ROIContourSequence[0].ContourSequence[
+        0
+    ].ContourGeometricType = "PYRIGHT_WONT_LIKE_THIS"
 
     print("Everything ran, no errors!")

--- a/rai/dicom/dummy.py
+++ b/rai/dicom/dummy.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from copy import deepcopy
+
 import pydicom
 
 from .append import append_dict_to_dataset
@@ -40,8 +42,13 @@ def _type_hint_effects():
     a.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "OPEN_PLANAR"
 
     # Editing the type for standard pydicom object
-    b = pydicom.Dataset(a)
+    b = pydicom.Dataset(deepcopy(a))
     b.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "OPEN_PLANAR"
 
     # Checking for equality
     assert a == b
+
+    # Without implementing the type checking, any valid CS value can be
+    # assigned to this variable without warning
+    b.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "ANYTHING_GOES"
+    assert a != b

--- a/rai/dicom/dummy.py
+++ b/rai/dicom/dummy.py
@@ -13,32 +13,35 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""DICOM dataset typing"""
-
-# TODO: Autogenerate this and force it to conform to the DICOM standard
-# as detailed within:
-# https://github.com/innolitics/dicom-standard/tree/master/standard
-
-from typing import Literal
-
 import pydicom
 
-# pylint: disable = missing-class-docstring
+from .append import append_dict_to_dataset
+from .typing import TypedDataset
 
 
-class ContourImageSequenceItem(pydicom.Dataset):
-    ReferencedSOPInstanceUID: str
+def run():
+    """Dummy docstring"""
+    _type_hint_effects()
 
 
-class ContourSequenceItem(pydicom.Dataset):
-    ContourImageSequence: list[ContourImageSequenceItem]
-    ContourData: list[float]
-    ContourGeometricType: Literal["CLOSED_PLANAR"]
+def _type_hint_effects():
+    a = TypedDataset()
 
+    append_dict_to_dataset(
+        ds=a,
+        to_append={
+            "ROIContourSequence": [
+                {"ContourSequence": [{"ContourGeometricType": "CLOSED_PLANAR"}]}
+            ]
+        },
+    )
 
-class ROIContourSequenceItem(pydicom.Dataset):
-    ContourSequence: list[ContourSequenceItem]
+    # Editing the type
+    a.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "OPEN_PLANAR"
 
+    # Editing the type for standard pydicom object
+    b = pydicom.Dataset(a)
+    b.ROIContourSequence[0].ContourSequence[0].ContourGeometricType = "OPEN_PLANAR"
 
-class TypedDataset(pydicom.Dataset):
-    ROIContourSequence: list[ROIContourSequenceItem]
+    # Checking for equality
+    assert a == b


### PR DESCRIPTION
> > It's okay here to gradually grow types. It won't silently ignore if a different contour type is utilised. In fact it will scream very loudly.
> 
> I'd like to see that in a test.

-- @sjswerdloff in https://github.com/RadiotherapyAI/rai/pull/83#issuecomment-1253344622

Even though we fixed up that issue for that given PR, I still want to go through the "Trust but Verify, or alternatively, Show Me." process. Given that if there is a pattern in my head that is false, that is in and of itself dangerous even if that pattern was picked up in the previous code review.

Therefore, this is a dummy pull request (not for merging) with the aim to demonstrate what I was describing with the intent to alleviate any concerns.

Here, I have reverted the type hint back to just the following:

https://github.com/RadiotherapyAI/rai/blob/0a36c418be39714a488376c96a7f2ca45e03f301/rai/dicom/typing.py#L36

I then created the following dummy file and made it runnable by calling `rai dummy`:

https://github.com/RadiotherapyAI/rai/blob/396eb38368183bea97e2c8262b93dcb492729534/rai/dicom/dummy.py#L29-L62

When running the above I get the following:

```bash
$ poetry run rai dummy
Everything ran, no errors!
```

But, importantly, when I run pyright, I get the following:

```bash
$ poetry run pyright
No configuration file found.
pyproject.toml file found at /home/simon/git/rai.
Loading pyproject.toml file at /home/simon/git/rai/pyproject.toml
Assuming Python version 3.10
Assuming Python platform Linux
Searching for source files
Found 18 source files
pyright 1.1.271
/home/simon/git/rai/rai/dicom/dummy.py
  /home/simon/git/rai/rai/dicom/dummy.py:42:71 - error: Cannot assign member "ContourGeometricType" for type "ContourSequenceItem"
    "Literal['OPEN_PLANAR']" cannot be assigned to type "Literal['CLOSED_PLANAR']" (reportGeneralTypeIssues)
  /home/simon/git/rai/rai/dicom/dummy.py:56:71 - error: Cannot assign member "ContourGeometricType" for type "ContourSequenceItem"
    "Literal['PYRIGHT_UNHAPPY']" cannot be assigned to type "Literal['CLOSED_PLANAR']" (reportGeneralTypeIssues)
2 errors, 0 warnings, 0 informations 
Completed in 4.665sec
```

Both of these errors are screaming at me within my editor as I type:

![image](https://user-images.githubusercontent.com/6559099/191597436-3a269b0d-7421-489d-9bf9-b4f718d21199.png)

![image](https://user-images.githubusercontent.com/6559099/191597470-6ad7a585-3a04-4c29-8a29-94608a6ea3ad.png)

And the errors are being flagged by the CI suite:

https://github.com/RadiotherapyAI/rai/actions/runs/3100642078/jobs/5021141020#step:14:22

Of note though, the following line doesn't raise any errors in pyright:

https://github.com/RadiotherapyAI/rai/blob/396eb38368183bea97e2c8262b93dcb492729534/rai/dicom/dummy.py#L53

And that's because, by default, pydicom dataset types are set to the typehint of `Any`:

![image](https://user-images.githubusercontent.com/6559099/191595751-4117dd36-b088-46ce-9c25-3f8a2d594bfb.png)

But also, even though there are pyright errors, and even though `OPEN_PLANAR` wasn't yet included within the type hinting, when I run the following at runtime:

https://github.com/RadiotherapyAI/rai/blob/396eb38368183bea97e2c8262b93dcb492729534/rai/dicom/dummy.py#L41-L49

There are no errors. And that's because type hinting doesn't actually override any of the original object's runtime functionality.

Essentially, type hints are designed to be only run during type checking. Type checking is designed to be run by your editor and your testing suite. There are libraries that read the type hints and force them to result in run-time errors if they are wrong. But I am not using any of those libraries for the time being. Whether or not we should force type hints to result in runtime errors is certainly up for discussion, but type hints resulting in runtime errors was not the intended purpose of the inclusion of type hints within the python language by the python core developers.

---

Currently, pydicom is set to `Any` typing, which means anything goes (including incorrect values). By restricting the types to a subset of the standard, now if something is allowed by the type checker, then it is also within the standard, but, the type checker might raise false errors in the case where the defined typing subset does not yet include that part of the standard. So, the way I see it, pydicom by default allows for false passes (by design). When including type checking based on a subset of the standard false passes now won't get past the type checker, but it will potentially go overboard and raise some false errors, at which point, the type hints need to be expanded to include that part of the type checker.

So, given the above, I do not believe there is any way that "under-defining" a type hint to a subset of the standard should result in a safety issue. However, leaving it as is, as `Any`, would be a problem.

Let me know if you believe differently.

Cheers :),
Simon